### PR TITLE
RHTAP prep for release-2.11

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,0 +1,18 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /go/src/github.com/stolostron/node_exporter
+COPY . .
+RUN go mod vendor && make build
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest 
+
+COPY --from=builder /go/src/github.com/stolostron/node_exporter/node_exporter /bin/node_exporter
+ 
+RUN microdnf update -y && microdnf install -y virt-what && microdnf clean all && rm -rf /var/cache/*
+
+EXPOSE      9100
+USER        nobody
+ENTRYPOINT  [ "/bin/node_exporter" ]


### PR DESCRIPTION
Required by [ACM-10834](https://issues.redhat.com/browse/ACM-10834)

Add docker file for RHTAP builds (with a new base image) to release-2.11 builds

cc: @Kyl-Bempah 