### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for node-exporter-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -19,7 +19,8 @@ USER        nobody
 ENTRYPOINT  [ "/bin/node_exporter" ]
 
 LABEL com.redhat.component="node-exporter" \
-  name="node-exporter" \
+  name="rhacm2/node-exporter-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.14::el9" \
   summary="node-exporter" \
   io.openshift.expose-services="" \
   io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
