### PR TITLE
Set UID instead of username

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -16,7 +16,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/node_exporter/node_exporter /bin/node_exporter
 
 EXPOSE      9100
-USER        nobody
+USER        1001
 ENTRYPOINT  [ "/bin/node_exporter" ]
 
 LABEL com.redhat.component="node-exporter" \

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -11,5 +11,5 @@ COPY --from=builder /go/src/github.com/stolostron/node_exporter/node_exporter /b
 RUN microdnf update -y && microdnf install -y virt-what && microdnf clean all && rm -rf /var/cache/*
 
 EXPOSE      9100
-USER        nobody
+USER        1001
 ENTRYPOINT  [ "/bin/node_exporter" ]


### PR DESCRIPTION
Fixes the following which occurs in MCOA on non-ocp clusters.

```
CreateContainerConfigError: “container has runAsNonRoot and image has non-numeric user (nobody),  cannot verify user is non-root”
```