### PR TITLE
Update build command to include cgo flag

### DIFF
--- a/.promu-cgo.yml
+++ b/.promu-cgo.yml
@@ -1,11 +1,12 @@
 go:
     # Whenever the Go version is updated here, .circle/config.yml and
     # .promu.yml should also be updated.
-    version: 1.22
+    version: 1.25
     cgo: true
 repository:
     path: github.com/prometheus/node_exporter
 build:
+    static: false
     binaries:
         - name: node_exporter
     ldflags: |

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -8,7 +8,8 @@ COPY . .
 
 RUN cd promu && go build -mod=mod -o /cachi2/output/deps/gomod/bin/promu
 
-RUN go mod vendor && make common-build
+# adding the cgo flag here to not break the architecture CI builds
+RUN go mod vendor && /cachi2/output/deps/gomod/bin/promu -c .promu-cgo.yml build -v --cgo --prefix /go/src/github.com/stolostron/node_exporter
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest 
 


### PR DESCRIPTION
Added cgo flag to the build process to support architecture CI builds.