### PR TITLE
Cherrypick add e2e test to 2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - "release-*"
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.25.x"
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install tools
+        run: |
+          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+          go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+          go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+      - name: Run tests
+        run: |
+          make SKIP_GOLANGCI_LINT=1
+          mkdir -p .build/linux-amd64
+          cp node_exporter .build/linux-amd64/node_exporter
+          make docker DOCKER_ARCHS=amd64
+          make test-docker
+          docker run --rm -t -v "$(pwd):/app" quay.io/prometheus/golang-builder:1.25-base -i github.com/prometheus/node_exporter -T
+          make -C docs/node-mixin clean
+          make -C docs/node-mixin jb_install
+          make -C docs/node-mixin
+          git diff --exit-code

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,9 @@
 extends: default
 ignore: |
   ui/react-app/node_modules
+  .circleci/
+  .tekton/
+  .promu.prow.yml
 
 rules:
   braces:


### PR DESCRIPTION
This MR is a backport of #239 that adds end to end tests to GitHub Actions on release-2.11